### PR TITLE
uses default for opts so that the linters mark it as optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,51 +172,51 @@ class Logger {
     }
   }
 
-  i(message, opts) {
+  i(message, opts = {}) {
     this.doLog('info', message, opts);
   }
 
-  l(message, opts) {
+  l(message, opts = {}) {
     return this.i(message, opts);
   }
 
-  log(message, opts) {
+  log(message, opts = {}) {
     return this.i(message, opts);
   }
 
-  info(message, opts) {
+  info(message, opts = {}) {
     return this.i(message, opts);
   }
 
-  e(message, opts) {
+  e(message, opts = {}) {
     this.doLog('error', message, opts);
   }
 
-  error(message, opts) {
+  error(message, opts = {}) {
     return this.e(message, opts);
   }
 
-  w(message, opts) {
+  w(message, opts = {}) {
     this.doLog('warn', message, opts);
   }
 
-  warn(message, opts) {
+  warn(message, opts = {}) {
     return this.w(message, opts);
   }
 
-  warning(message, opts) {
+  warning(message, opts = {}) {
     return this.w(message, opts);
   }
 
-  d(message, opts) {
+  d(message, opts = {}) {
     this.doLog('debug', message, opts);
   }
 
-  debug(message, opts) {
+  debug(message, opts = {}) {
     return this.d(message, opts);
   }
 
-  test(message, opts) {
+  test(message, opts = {}) {
     if (opts) {
       console.log(message, opts);
     } else {


### PR DESCRIPTION
Some of the API linters were complaining that opts was required, using default marks it as default.

![Screen Shot 2020-07-02 at 11 44 54](https://user-images.githubusercontent.com/7119875/86387902-79cfe380-bc59-11ea-863a-c24cd8c472e9.png)
