### PR TITLE
Better formatting for local/dev development

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,7 @@ const _ = require('lodash');
 const { createWriteStream } = require('fs');
 
 const FORMAT_JSON = format.json();
-const FORMAT_SIMPLE = format.simple();
-const FORMAT_DEV = format.combine(
-  format.simple(),
-  format.colorize(),
-)
+const FORMAT_DEV = format.cli();
 
 class Logger {
   /**

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { createWriteStream } = require('fs');
 
 const FORMAT_JSON = format.json();
 const FORMAT_SIMPLE = format.simple();
+const FORMAT_DEV = format.prettyPrint({ colorize: true })
 
 class Logger {
   /**
@@ -41,7 +42,7 @@ class Logger {
 
   initializeLogger(options, metadata, customTransports) {
     const logFormat =
-      metadata.environment === 'dev' ? FORMAT_SIMPLE : FORMAT_JSON;
+      metadata.environment === 'dev' ? FORMAT_DEV : FORMAT_JSON;
 
     return createLogger({
       level: 'info',

--- a/index.js
+++ b/index.js
@@ -8,7 +8,10 @@ const { createWriteStream } = require('fs');
 
 const FORMAT_JSON = format.json();
 const FORMAT_SIMPLE = format.simple();
-const FORMAT_DEV = format.prettyPrint({ colorize: true })
+const FORMAT_DEV = format.combine(
+  format.colorize(),
+  format.simple()
+)
 
 class Logger {
   /**

--- a/index.js
+++ b/index.js
@@ -9,8 +9,8 @@ const { createWriteStream } = require('fs');
 const FORMAT_JSON = format.json();
 const FORMAT_SIMPLE = format.simple();
 const FORMAT_DEV = format.combine(
+  format.simple(),
   format.colorize(),
-  format.simple()
 )
 
 class Logger {


### PR DESCRIPTION
Adds the formatting to look as close as what it used to look with the previous logger implementation.

<img width="708" alt="Screen Shot 2020-07-02 at 17 44 29" src="https://user-images.githubusercontent.com/7119875/86415239-07c4c200-bc8c-11ea-8168-b200f860fc46.png">
