### PR TITLE
adds custom formatter for dev logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,14 @@ const _ = require('lodash');
 const { createWriteStream } = require('fs');
 
 const FORMAT_JSON = format.json();
-const FORMAT_DEV = format.cli();
+
+const devPrinter = ({ level, message, metadata }) => {
+  const stringifiedMetadata = util.inspect(metadata)
+  if (stringifiedMetadata !== '{}') {
+    return `${level}: ${message} ${util.inspect(metadata)}` ;
+  }
+  return `${level}: ${message}` ;
+}
 
 class Logger {
   /**
@@ -39,9 +46,16 @@ class Logger {
     });
   }
 
+  getDevFormat() {
+    return format.combine(
+      format.colorize(),
+      format.printf(devPrinter)
+    );
+  }
+
   initializeLogger(options, metadata, customTransports) {
     const logFormat =
-      metadata.environment === 'dev' ? FORMAT_DEV : FORMAT_JSON;
+    metadata.environment === 'dev' ? this.getDevFormat() : FORMAT_JSON;
 
     return createLogger({
       level: 'info',


### PR DESCRIPTION
This PR implements a custom formatter, the reason is that the format.cli one does not process metadata and a lot of logs depend on it for example `log.info('This is the payload', payload)` (it also adds padding which I did not like), so a lot of logs did not show on the console properly. With this, the logs look the same (or almost the same) as the previous implementation of logs:

<img width="1041" alt="Screen Shot 2020-07-06 at 9 45 53" src="https://user-images.githubusercontent.com/7119875/86609522-a5acdb00-bf71-11ea-9f0b-39f58fece623.png">
