### PR TITLE
Fix curly bracket old implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ class Logger {
     const methodNameCapitalized =
       methodName.charAt(0).toUpperCase() + methodName.slice(1);
     this.setProcess(
-      `${this.classProcessName}) (methods:${methodNameCapitalized}`,
+      `${this.classProcessName}] [methods:${methodNameCapitalized}`,
     );
   }
 


### PR DESCRIPTION
New implementation uses square brackets.

I'm getting something like this:
`[account.js) (methods:UpsertAccount]: Account upserted`