### PR TITLE
BAC-1306 adds error serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -280,6 +280,14 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
+    "serialize-error": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
+      "integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
     "shimmer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
@@ -320,6 +328,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "express-http-context": "^1.2.3",
     "lodash": "^4.17.15",
+    "serialize-error": "^8.0.1",
     "winston": "^3.3.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is part of the improvement of error handling for audit logs but it will be useful for all JS microservices.

Error Objects are currently not being logged by our JS logger when transforming the log in JSON, this affects logs like this

```javascript
catch(error) {
  log.error('something bad happened', error)
}
```

The error appears fine when developing but the error disappears when checking datadog logs, the reason is that Error Objects cannot be stringified. So the errors need to be serialized.

I used the serialize-error library and it's compatible with vanilla Error objects and VError ones. This is an example of what it looks like when using the JSON formatter of the logger (the one used by the environments).

This is what a VError looks like with these changes:

<img width="1429" alt="Screen Shot 2021-02-11 at 11 28 38" src="https://user-images.githubusercontent.com/7119875/107678290-d28c4380-6c60-11eb-97de-391d333910a4.png">

This is what a vanilla Error looks like with these changes:

<img width="1429" alt="Screen Shot 2021-02-11 at 12 02 09" src="https://user-images.githubusercontent.com/7119875/107678435-010a1e80-6c61-11eb-9763-90491c46abe6.png">
